### PR TITLE
修复同一天发表两篇文章，后一篇因为在日报发布后发表而被漏抓问题

### DIFF
--- a/R/fetch.R
+++ b/R/fetch.R
@@ -19,7 +19,7 @@ for (i in 1:NROW(m)) {
                 # fewer characters for wider chars
                 description = substr(description, 1, 600 * nchar(description) / nchar(description, 'width'))
                 a$description = paste(sub(' +[^ ]{1,20}$', '', description), '...')
-                n <- sum(as.POSIXct(a$date[1:NROW(a)])>as.POSIXct(m[i,2]))
+                n <- sum(as.POSIXct(a$date[1:NROW(a)]) >= as.POSIXct(m[i,2]))
         }else{
                 n <- 0
         }

--- a/R/list.txt
+++ b/R/list.txt
@@ -158,3 +158,4 @@
 "rud.is/b/feed/","2021-09-07"
 "cxy.rbind.io/index.xml","2021-09-07"
 "andrewgelman.com/feed/","2021-09-07"
+"https://www.r-bloggers.com/feed","0001-01-01"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Daily News/Blog aggregator website and you could use this website as a template 
 - Use `getrss` from [scifetch](https://github.com/yufree/scifetch) to convert rss xml file into dataframe and use the following code to generate `md` files and PR to this repo.
 
 ```r
+if (!dir.exists("content")) dir.create("content")
+if (!dir.exists("content/post")) dir.create("content/post")
 x <- scifetch::getrss('path-to-your-own-rss-xml-files')
 for (i in 1:NROW(x)) {
     name = gsub("^http[s]?://|/$", "", tolower(x[i, 'linkTitle']))

--- a/content/about.md
+++ b/content/about.md
@@ -31,6 +31,8 @@ Daily News/Blog aggregator website and you could use this website as a template 
 - Use `getrss` from [scifetch](https://github.com/yufree/scifetch) to convert rss xml file into dataframe and use the following code to generate `md` files and PR to this repo.
 
 ```r
+if (!dir.exists("content")) dir.create("content")
+if (!dir.exists("content/post")) dir.create("content/post")
 x <- scifetch::getrss('path-to-your-own-rss-xml-files')
 for (i in 1:NROW(x)) {
     name = gsub("^http[s]?://|/$", "", tolower(x[i, 'linkTitle']))


### PR DESCRIPTION
同一天可能发表两篇文章，比如我在2021年9月5日发表了[两篇文章](https://cxy.rbind.io/)，一篇在 Dailyr R 日报发布之前，这篇文章可以正常被日报收录，此时 list.txt 的 update 被更新为 “2021-09-05”，但是另一篇文章是在日报发布之后发表的，虽然发表日期也是2021年9月5日，但是下次日报会取 update 日期（2021-09-05）之后的文章，这样我的第二篇文章就被漏掉了。因此，建议下次日报取 >= update 之后的文章，这样就不会漏掉文章，虽然第一篇文章会被重复抓取，但是也只是被覆盖，问题不大。